### PR TITLE
[SC-61] Add Dai IRS for reading the jug SF value instead of pot DSR

### DIFF
--- a/src/DaiJugInterestRateStrategy.sol
+++ b/src/DaiJugInterestRateStrategy.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.10;
+
+import {IERC20} from 'aave-v3-core/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
+import {IReserveInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IReserveInterestRateStrategy.sol';
+import {DataTypes} from 'aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol';
+
+interface VatLike {
+    function live() external view returns (uint256);
+    function ilks(bytes32) external view returns (uint256, uint256, uint256, uint256, uint256);
+}
+
+interface JugLike {
+    function ilks(bytes32) external view returns (uint256, uint256);
+}
+
+/**
+ * @title DaiInterestRateStrategy
+ * @notice Flat interest rate curve which is a spread on the Stability Fee Base Rate unless Maker needs liquidity.
+ * @dev The interest rate strategy is intended to be used by Spark Lend pool that is supplied by a D3M implementation. Further, is implemented for DAI so that a D3M implementation for the Spark Lend protocol should be able to unwind as fast as possible in case of debt limit changes downwards by incentivizing borrowers and lenders to move DAI into the protocol. Hence, it operates in two modes. Namely, it distinguishes the unhealthy scenario, where the D3M supplied too much (the Spark Lend D3M ink's debt exceeds the debt limit), from the healthy one, where the D3M is healthy.
+ * 
+ * Note that the base rate conversion, maximum rate and the borrow and supply spreads are constants, while the DSR rate is queried from Maker's Jug contract. The base rate is defined as:
+ * 
+ * ```
+ * Rbase = min(Rdsr * baseRateConversion, Rmax − RborrowSpread)
+ * ```
+ * 
+ * Meaning, that the sum of the base rate and the borrow spread cannot exceed the maximum rate.
+ * 
+ * Assume the D3M is healthy. The borrow rate is a constant defined as the Dai Savings Rate plus a borrow spread. While the borrowed amount is below a certain performance value, the supply rate is set to zero. Once the borrowed amount reaches the performance value, the supply rate is computed as the Dai Savings Rate plus a supply spread, multiplied with the ratio of the amount, that went over the premium and the total liquidity (borrows + available capital) in the pool. Hence, the rates can be described as follows:
+ * 
+ * ```
+ * Rborrow = Rbase + RborrowSpread
+ * Rsupply = (Rbase + RsupplySpread) * max(0, Cborrowed − Cperformance) / (Cborrowed + Cavailable)
+ * ```
+ * 
+ * Note it yields that the borrow rate is always constant. Further, suppliers are only incentivized to supply capital after a minimum borrow amount is reached. During the times, as the third-party suppliers are not incentivized, we expect that the D3M provides sufficient DAI for the lending market. However, once the protocol makes sufficient profits, it will incentivize third party suppliers (as the D3M will have a certain debt limit).
+ * 
+ * In case the D3M is unhealthy, meaning that the debt is higher than the debt limit, the D3M will try to wind down. In that scenario, the interest rate strategy will try to incentivize borrowers to pay back their debt, and will try to incentivize suppliers to start lending DAI. Hence, the borrow and supply rate will increase according to the debt ratio of the D3M. More specifically, the rates are defined as:
+ * 
+ * ```
+ * Rborrow = Rmax − (Rmax − (rbase + rborrowSpread)) / debtRatio
+ * Rsupply = (Cborrowed / (Cborrowed + Cavailable)) * Rborrow
+ * ```
+ * 
+ * Note, that if the debt ratio increases, the borrow rate increases as a negated inverse function (starting at the regular borrowing rate). Similarly, the supply rate will increase in terms of the debt ratio, however, scaled by the utilization ratio. Thus, the higher the utilization, the closer will the supply rate be to the borrow rate. Ultimately, that leads to the protocol forfeiting potential revenue by sharing it with third-party supplier to incentivize the D3M's stabilization. Note that the stable borrow rate is always 0.
+ * 
+ * The interest rate definition described above is implemented in calculateInterestRates(). However, note that the debt ratio and the base rate are both not queried on every interest rate calculation; but, retrieved from a cache (as these will not change often). The variables can be recomputed with function recompute() that sets the base rate to the current Dai Savings Rate and computes the debt ratio as the ratio of the current Ilk.Art and current Ilk.line. It is assumed that the recomputation is triggered on a regular basis.
+ * 
+ * Only supports variable interest pool.
+ */
+contract DaiJugInterestRateStrategy is IReserveInterestRateStrategy {
+
+    struct Slot0 {
+        // The ratio of outstanding debt to debt ceiling in the vault. Expressed in wad
+        uint88 debtRatio;
+        // The base rate of the reserve. Expressed in ray
+        uint128 baseRate;
+        // Timestamp of last update
+        uint40 lastUpdateTimestamp;
+    }
+
+    uint256 private constant HWAD = 10 ** 9;
+    uint256 private constant WAD = 10 ** 18;
+    uint256 private constant RAY = 10 ** 27;
+    uint256 private constant RAD = 10 ** 45;
+    uint256 private constant SECONDS_PER_YEAR = 365 days;
+
+    address public immutable vat;
+    address public immutable jug;
+    bytes32 public immutable dsrIlk;
+    bytes32 public immutable ilk;
+    uint256 public immutable baseRateConversion;
+    uint256 public immutable borrowSpread;
+    uint256 public immutable supplySpread;
+    uint256 public immutable maxRate;
+    uint256 public immutable performanceBonus;
+
+    Slot0 private _slot0;
+
+    /**
+     * @param _vat The address of the vat contract
+     * @param _jug The address of the jug contract
+     * @param _dsrIlk The ilk identifier for the dsr value
+     * @param _ilk The ilk identifier
+     * @param _baseRateConversion Convert Dai Savings Rate to the Stability Fee Base Rate (SFBR) as a RAY unit
+     * @param _borrowSpread The borrow spread on top of the SFBR as an APR in RAY units
+     * @param _supplySpread The supply spread on top of the SFBR as an APR in RAY units
+     * @param _maxRate The maximum rate that can be returned by this strategy in RAY units
+     * @param _performanceBonus The first part of the interest earned on the debt goes to the reserve as a performance bonus in WAD units.
+     */
+    constructor(
+        address _vat,
+        address _jug,
+        bytes32 _dsrIlk,
+        bytes32 _ilk,
+        uint256 _baseRateConversion,
+        uint256 _borrowSpread,
+        uint256 _supplySpread,
+        uint256 _maxRate,
+        uint256 _performanceBonus
+    ) {
+        require(_borrowSpread >= _supplySpread, "DaiInterestRateStrategy/supply-spread-greater-than-borrow-spread");
+        require(_maxRate >= _borrowSpread, "DaiInterestRateStrategy/borrow-spread-too-large");
+
+        vat = _vat;
+        jug = _jug;
+        dsrIlk = _dsrIlk;
+        ilk = _ilk;
+        baseRateConversion = _baseRateConversion;
+        borrowSpread = _borrowSpread;
+        supplySpread = _supplySpread;
+        maxRate = _maxRate;
+        performanceBonus = _performanceBonus;
+
+        recompute();
+    }
+
+    /**
+    * @notice Fetch debt ceiling and dsr. Expensive operation should be called only when underlying values change.
+    * @dev This incurs a lot of SLOADs and infrequently changes. No need to call this on every calculation.
+    */
+    function recompute() public {
+        (uint256 Art, uint256 rate,, uint256 line,) = VatLike(vat).ilks(ilk);
+        // Convert the DSR to the SFBR as a yearly APR
+        (uint256 dsr,) = JugLike(jug).ilks(dsrIlk);
+        uint256 baseRate = (dsr - RAY) * SECONDS_PER_YEAR * baseRateConversion / RAY;
+        
+        // Base rate + borrow spread cannot be larger than the max rate
+        if (baseRate + borrowSpread > maxRate) {
+            unchecked {
+                baseRate = maxRate - borrowSpread;  // This is safe because borrowSpread <= maxRate in constructor
+            }
+        }
+
+        uint256 _line = line / WAD;
+        uint256 debtRatio = Art > 0 ? ((_line > 0 && VatLike(vat).live() == 1) ? Art * rate / _line : type(uint88).max) : 0;
+        if (debtRatio > type(uint88).max) {
+            debtRatio = type(uint88).max;
+        }
+
+        _slot0 = Slot0({
+            debtRatio: uint88(debtRatio),
+            baseRate: uint128(baseRate),
+            lastUpdateTimestamp: uint40(block.timestamp)
+        });
+    }
+
+    /// @inheritdoc IReserveInterestRateStrategy
+    function calculateInterestRates(DataTypes.CalculateInterestRatesParams memory params)
+        external
+        view
+        override
+        returns (
+            uint256 supplyRate,
+            uint256 stableBorrowRate,
+            uint256 variableBorrowRate
+        )
+    {
+        stableBorrowRate = 0;   // Avoid warning message
+
+        Slot0 memory slot0 = _slot0;
+
+        uint256 baseRate = slot0.baseRate;
+        uint256 outstandingBorrow = params.totalVariableDebt;
+        uint256 supplyUtilization;
+        
+        if (outstandingBorrow > 0) {
+            uint256 availableLiquidity =
+                IERC20(params.reserve).balanceOf(params.aToken) +
+                params.liquidityAdded -
+                params.liquidityTaken;
+            supplyUtilization = outstandingBorrow * WAD / (availableLiquidity + outstandingBorrow);
+        }
+
+        uint256 debtRatio = slot0.debtRatio;
+        variableBorrowRate = baseRate + borrowSpread;
+        if (debtRatio <= WAD) {
+            // Maker has enough liquidity - rates are flat
+            if (outstandingBorrow > performanceBonus) {
+                uint256 delta;
+                unchecked {
+                    delta = outstandingBorrow - performanceBonus;
+                }
+                supplyRate =
+                    (baseRate + supplySpread) *     // Flat rate
+                    supplyUtilization / WAD *       // Supply utilization
+                    delta / outstandingBorrow;      // Performance bonus deduction
+            }
+        } else {
+            // Maker needs liquidity - rates increase until D3M debt is brought back to the debt ceiling
+            uint256 maxRateDelta;
+            unchecked {
+                maxRateDelta = maxRate - variableBorrowRate;  // Safety enforced by conditional above
+            }
+            
+            variableBorrowRate = maxRate - maxRateDelta * WAD / debtRatio;
+
+            // Drop the performance bonus to incentivize third party suppliers as much as possible
+            supplyRate = variableBorrowRate * supplyUtilization / WAD;
+        }
+    }
+
+    function getDebtRatio() external view returns (uint256) {
+        return _slot0.debtRatio;
+    }
+
+    function getBaseRate() external view returns (uint256) {
+        return _slot0.baseRate;
+    }
+
+    function getLastUpdateTimestamp() external view returns (uint256) {
+        return _slot0.lastUpdateTimestamp;
+    }
+
+}

--- a/test/DaiJugInterestRateStrategy.t.sol
+++ b/test/DaiJugInterestRateStrategy.t.sol
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.10;
+
+import "dss-test/DssTest.sol";
+
+import "../src/DaiJugInterestRateStrategy.sol";
+
+contract VatMock {
+
+    uint256 Art;
+    uint256 line;
+    uint256 public live = 1;
+
+    function ilks(bytes32) public view returns (uint256, uint256, uint256, uint256, uint256) {
+        return (Art, 10 ** 27, 0, line, 0);
+    }
+
+    function setArt(uint256 _art) external {
+        Art = _art;
+    }
+
+    function setLine(uint256 _line) external {
+        line = _line;
+    }
+
+    function cage() external {
+        live = 0;
+    }
+
+}
+
+contract JugMock {
+
+    uint256 public dsr;
+
+    function ilks(bytes32) public view returns (uint256, uint256) {
+        return (dsr, 0);
+    }
+
+    function setDSR(uint256 _dsr) external {
+        dsr = _dsr;
+    }
+
+}
+
+contract DaiMock {
+
+    uint256 public liquidity;
+
+    function balanceOf(address) external view returns (uint256) {
+        return liquidity;
+    }
+
+    function setLiquidity(uint256 _liquidity) external {
+        liquidity = _liquidity;
+    }
+
+}
+
+contract DaiJugInterestRateStrategyTest is DssTest {
+
+    VatMock vat;
+    JugMock jug;
+    DaiMock dai;
+
+    DaiJugInterestRateStrategy interestStrategy;
+    DaiJugInterestRateStrategy interestStrategyNoSubsidy;
+
+    bytes32 constant ILK = "DIRECT-SPARK-DAI";
+    bytes32 constant ILK_JUG = "ETH-C";
+    uint256 constant DSR_ONE_PERCENT = 1000000000315522921573372069;
+    uint256 constant DSR_TWO_HUNDRED_PERCENT = 1000000034836767751273470154;
+    uint256 constant BR = 11055923171930957297759999;    // DSR at 1% / 90% to get SFBR as yearly APR
+    uint256 constant RBPS = RAY / 10000;
+    uint256 constant ONE_TRILLION = 1_000_000_000_000;
+
+    function setUp() public {
+        vat = new VatMock();
+        vat.setLine(1_000_000 * RAD);
+        jug = new JugMock();
+        jug.setDSR(DSR_ONE_PERCENT);
+        dai = new DaiMock();
+
+        interestStrategy = new DaiJugInterestRateStrategy(
+            address(vat),
+            address(jug),
+            ILK_JUG,
+            ILK,
+            100 * RAY / 90,  // SFBR is defined as DSR / 90%
+            50 * RBPS,       // 0.5% borrow spread
+            25 * RBPS,       // 0.25% supply spread
+            7500 * RBPS,     // 75% max rate
+            100_000 * WAD    // 100k is reserved for performance bonus
+        );
+    }
+
+    function test_constructor() public {
+        assertEq(address(interestStrategy.vat()), address(vat));
+        assertEq(address(interestStrategy.jug()), address(jug));
+        assertEq(interestStrategy.ilk(), ILK);
+        assertEq(interestStrategy.baseRateConversion(), 1111111111111111111111111111);
+        assertEq(interestStrategy.borrowSpread(), 50 * RBPS);
+        assertEq(interestStrategy.supplySpread(), 25 * RBPS);
+        assertEq(interestStrategy.maxRate(), 7500 * RBPS);
+        assertEq(interestStrategy.performanceBonus(), 100_000 * WAD);
+
+        // Recompute should occur
+        assertEq(interestStrategy.getDebtRatio(), 0);
+        assertEq(interestStrategy.getBaseRate(), BR);
+        assertEq(interestStrategy.getLastUpdateTimestamp(), block.timestamp);
+    }
+
+    function test_recompute() public {
+        vat.setArt(1_000_000 * WAD);
+        vat.setLine(2_000_000 * RAD);
+        jug.setDSR(RAY);
+        vm.warp(block.timestamp + 1 days);
+
+        assertEq(interestStrategy.getDebtRatio(), 0);
+        assertEq(interestStrategy.getBaseRate(), BR);
+        assertEq(interestStrategy.getLastUpdateTimestamp(), block.timestamp - 1 days);
+
+        interestStrategy.recompute();
+
+        assertEq(interestStrategy.getDebtRatio(), WAD / 2);
+        assertEq(interestStrategy.getBaseRate(), 0);
+        assertEq(interestStrategy.getLastUpdateTimestamp(), block.timestamp);
+    }
+
+    function test_calculateInterestRates_no_maker_debt_no_borrows() public {
+        assertRates(0, 0, BR + 50 * RBPS, "No Maker debt, no borrows. supply = 0, borrow = dsr + 50bps");
+    }
+
+    function test_calculateInterestRates_no_maker_debt_with_borrows() public {
+        dai.setLiquidity(200_000 * WAD);
+
+        assertRates(100_000 * WAD, 0, BR + 50 * RBPS, "No Maker debt, user-only supply under performance bonus. supply = 0, borrow = dsr + 50bps");
+        assertRates(200_000 * WAD, (BR + 25 * RBPS) * 1 / 2 * 1 / 2, BR + 50 * RBPS, "No Maker debt, user-only supply over performance bonus. supply = 0, borrow = dsr + 50bps");
+    }
+
+    function test_calculateInterestRates_maker_debt_no_borrows() public {
+        vat.setArt(200_000 * WAD);
+        dai.setLiquidity(200_000 * WAD);
+        interestStrategy.recompute();
+
+        assertRates(0, 0, BR + 50 * RBPS, "Only Maker as LP. supply = 0, borrow = dsr + 50bps");
+    }
+
+    function test_calculateInterestRates_maker_debt_with_borrows() public {
+        vat.setArt(200_000 * WAD);
+        dai.setLiquidity(100_000 * WAD);
+        interestStrategy.recompute();
+
+        assertRates(100_000 * WAD, 0, BR + 50 * RBPS, "Only Maker as LP, borrows under performance bonus. supply = 0, borrow = dsr + 50bps");
+        dai.setLiquidity(0);    // Pool is fully utilized
+        assertRates(200_000 * WAD, (BR + 25 * RBPS) * 1 / 2, BR + 50 * RBPS, "Only Maker as LP, borrows over performance bonus. supply = 0, borrow = dsr + 50bps");
+    }
+
+    function test_calculateInterestRates_over_debt_limit() public {
+        vat.setArt(2_000_000 * WAD);    // 2x over capacity
+        interestStrategy.recompute();
+
+        uint256 br = 7500 * RBPS - (7500 * RBPS - (BR + 50 * RBPS)) / 2;
+        assertEq(br, 383027961585965478648880000, "borrow rate should be about half of max rate");
+        assertRates(2_000_000 * WAD, br, br, "Only Maker as LP, 2x over capacity, 100% utilization. supply = ~maxRate/2, borrow = ~maxRate/2");
+        dai.setLiquidity(1_000_000 * WAD);  // User adds some liquidity, still over capacity
+        assertRates(2_000_000 * WAD, 255351974390643652177234692, br, "Maker+Users as LP, 2x over capacity, 66.7% utilization. supply = ~maxRate/2 * 66.7%, borrow = ~maxRate/2");
+    }
+
+    function test_calculateInterestRates_debt_ceiling_zero() public {
+        vat.setLine(0);
+        vat.setArt(1);  // Infinitely over capacity even with 1 wei of debt
+        interestStrategy.recompute();
+
+        uint256 br = 749999997628498784959732204;   // Pretty much maxRate with some rounding errors
+        assertRates(100_000 * WAD, br, br, "Maker wants to go to zero debt - always maxRate. supply = maxRate, borrow = maxRate");
+    }
+
+    function test_calculateInterestRates_vat_caged() public {
+        vat.setArt(500_000 * WAD);
+        vat.cage();
+        interestStrategy.recompute();
+
+        uint256 br = 749999997628498784959732204;   // Pretty much maxRate with some rounding errors
+        assertRates(500_000 * WAD, br, br, "Should be near max rate when vat is caged. supply = maxRate, borrow = maxRate");
+    }
+
+    function test_calculateInterestRates_fuzz(
+        uint256 line,
+        uint256 art,
+        uint256 dsr,
+        uint256 baseRateConversion,
+        uint256 totalVariableDebt,
+        uint256 liquidity,
+        uint256 borrowSpread,
+        uint256 supplySpread,
+        uint256 maxRate,
+        uint256 performanceBonus
+    ) public {
+        // Keep the numbers sane
+        line = line % (ONE_TRILLION * RAD);
+        art = art % (ONE_TRILLION * WAD);
+        dsr = dsr % (DSR_TWO_HUNDRED_PERCENT - RAY) + RAY;
+        baseRateConversion = baseRateConversion % (10 * RAY);
+        totalVariableDebt = totalVariableDebt % (ONE_TRILLION * WAD);
+        liquidity = liquidity % (ONE_TRILLION * WAD);
+        maxRate = maxRate % 1_000_000_00 * RBPS;
+        borrowSpread = maxRate > 0 ? borrowSpread % maxRate : 0;
+        supplySpread = borrowSpread > 0 ? supplySpread % borrowSpread : 0;
+        performanceBonus = performanceBonus % (ONE_TRILLION * WAD);
+
+        interestStrategy = new DaiJugInterestRateStrategy(
+            address(vat),
+            address(jug),
+            ILK_JUG,
+            ILK,
+            baseRateConversion,
+            borrowSpread,
+            supplySpread,
+            maxRate,
+            performanceBonus
+        );
+
+        vat.setLine(line);
+        vat.setArt(art);
+        jug.setDSR(dsr);
+        dai.setLiquidity(liquidity);
+        interestStrategy.recompute();
+
+        uint256 supplyRatio = totalVariableDebt > 0 ? totalVariableDebt * WAD / (totalVariableDebt + liquidity) : 0;
+        (uint256 supplyRate,, uint256 borrowRate) = interestStrategy.calculateInterestRates(DataTypes.CalculateInterestRatesParams(
+            0,
+            0,
+            0,
+            0,
+            totalVariableDebt,
+            0,
+            0,
+            address(dai),
+            address(0)
+        ));
+
+        assertLe(supplyRatio, WAD, "supply ratio should be less than or equal to 1");
+        if (supplyRatio > 0) {
+            uint256 adjBorrowRate = borrowRate * supplyRatio;
+            assertGe(adjBorrowRate, supplyRate, "adjusted borrow rate should always be greater than or equal to the supply rate");
+        } else {
+            assertGe(borrowRate, supplyRate, "borrow rate should always be greater than or equal to the supply rate");
+        }
+        assertGe(borrowRate, interestStrategy.getBaseRate() + borrowSpread, "borrow rate should be greater than or equal to base rate + spread");
+        assertLe(borrowRate, maxRate, "borrow rate should be less than or equal to max rate");
+    }
+
+    function assertRates(
+        uint256 totalVariableDebt,
+        uint256 expectedSupplyRate,
+        uint256 expectedBorrowRate,
+        string memory errorMessage
+    ) internal {
+        (uint256 supplyRate,, uint256 borrowRate) = interestStrategy.calculateInterestRates(DataTypes.CalculateInterestRatesParams(
+            0,
+            0,
+            0,
+            0,
+            totalVariableDebt,
+            0,
+            0,
+            address(dai),
+            address(0)
+        ));
+
+        assertEq(supplyRate, expectedSupplyRate, errorMessage);
+        assertEq(borrowRate, expectedBorrowRate, errorMessage);
+    }
+
+}

--- a/test/DaiJugInterestRateStrategy.t.sol
+++ b/test/DaiJugInterestRateStrategy.t.sol
@@ -97,6 +97,7 @@ contract DaiJugInterestRateStrategyTest is DssTest {
     function test_constructor() public {
         assertEq(address(interestStrategy.vat()), address(vat));
         assertEq(address(interestStrategy.jug()), address(jug));
+        assertEq(interestStrategy.dsrIlk(), ILK_JUG);
         assertEq(interestStrategy.ilk(), ILK);
         assertEq(interestStrategy.baseRateConversion(), 1111111111111111111111111111);
         assertEq(interestStrategy.borrowSpread(), 50 * RBPS);


### PR DESCRIPTION
Adding a variant to the Dai Interest Rate Strategy that reads from a stability fee to get the dsr value rather than the actual dsr.

Integration tests can be done in the spell.