### PR TITLE
[SC-161] Add irs that target dynamic rates for kink and base

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,5 +44,5 @@ jobs:
           BASE_RPC_URL: ${{secrets.BASE_RPC_URL}}
           GOERLI_RPC_URL: ${{secrets.GOERLI_RPC_URL}}
         run: |
-          forge test -vvv
+          forge test -vvvv
         id: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,5 +44,5 @@ jobs:
           BASE_RPC_URL: ${{secrets.BASE_RPC_URL}}
           GOERLI_RPC_URL: ${{secrets.GOERLI_RPC_URL}}
         run: |
-          forge test -vvvv
+          forge test -vvv
         id: test

--- a/.gitmodules
+++ b/.gitmodules
@@ -24,6 +24,3 @@
 [submodule "lib/dss-test"]
 	path = lib/dss-test
 	url = https://github.com/makerdao/dss-test
-[submodule "lib/governance-crosschain-bridges"]
-	path = lib/governance-crosschain-bridges
-	url = https://github.com/marsfoundation/governance-crosschain-bridges

--- a/src/RateTargetBaseInterestRateStrategy.sol
+++ b/src/RateTargetBaseInterestRateStrategy.sol
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {IERC20} from 'aave-v3-core/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
+import {WadRayMath} from 'aave-v3-core/contracts/protocol/libraries/math/WadRayMath.sol';
+import {PercentageMath} from 'aave-v3-core/contracts/protocol/libraries/math/PercentageMath.sol';
+import {DataTypes} from 'aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol';
+import {Errors} from 'aave-v3-core/contracts/protocol/libraries/helpers/Errors.sol';
+import {IDefaultInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IDefaultInterestRateStrategy.sol';
+import {IReserveInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IReserveInterestRateStrategy.sol';
+import {IPoolAddressesProvider} from 'aave-v3-core/contracts/interfaces/IPoolAddressesProvider.sol';
+
+interface IRateSource {
+  function getAPR() external view returns (uint256);
+}
+
+/**
+ * @title RateTargetBaseInterestRateStrategy contract
+ * @author Aave
+ * @notice Implements the calculation of the interest rates depending on the reserve state and an external APR to target at the base
+ * @dev The model of interest rate is based on 2 slopes, one before the `OPTIMAL_USAGE_RATIO`
+ * point of usage and another from that one to 100%.
+ * - An instance of this same contract, can't be used across different Aave markets, due to the caching
+ *   of the PoolAddressesProvider
+ */
+contract RateTargetBaseInterestRateStrategy is IDefaultInterestRateStrategy {
+  using WadRayMath for uint256;
+  using PercentageMath for uint256;
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  uint256 public immutable OPTIMAL_USAGE_RATIO;
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  uint256 public immutable OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO;
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  uint256 public immutable MAX_EXCESS_USAGE_RATIO;
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  uint256 public immutable MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO;
+
+  IPoolAddressesProvider public immutable ADDRESSES_PROVIDER;
+
+  IRateSource public immutable RATE_SOURCE;
+
+  // Base variable borrow rate spread when usage rate = 0. Expressed in ray
+  uint256 internal immutable _baseVariableBorrowRateSpread;
+
+  // Slope of the variable interest curve when usage ratio > 0 and <= OPTIMAL_USAGE_RATIO. Expressed in ray
+  uint256 internal immutable _variableRateSlope1;
+
+  // Slope of the variable interest curve when usage ratio > OPTIMAL_USAGE_RATIO. Expressed in ray
+  uint256 internal immutable _variableRateSlope2;
+
+  // Slope of the stable interest curve when usage ratio > 0 and <= OPTIMAL_USAGE_RATIO. Expressed in ray
+  uint256 internal immutable _stableRateSlope1;
+
+  // Slope of the stable interest curve when usage ratio > OPTIMAL_USAGE_RATIO. Expressed in ray
+  uint256 internal immutable _stableRateSlope2;
+
+  // Premium on top of `_variableRateSlope1` for base stable borrowing rate
+  uint256 internal immutable _baseStableRateOffset;
+
+  // Additional premium applied to stable rate when stable debt surpass `OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO`
+  uint256 internal immutable _stableRateExcessOffset;
+
+  /**
+   * @dev Constructor.
+   * @param provider The address of the PoolAddressesProvider contract
+   * @param rateSource The address of the rate source contract
+   * @param optimalUsageRatio The optimal usage ratio
+   * @param baseVariableBorrowRateSpread The base variable borrow rate spread
+   * @param variableRateSlope1 The variable rate slope below optimal usage ratio
+   * @param variableRateSlope2 The variable rate slope above optimal usage ratio
+   * @param stableRateSlope1 The stable rate slope below optimal usage ratio
+   * @param stableRateSlope2 The stable rate slope above optimal usage ratio
+   * @param baseStableRateOffset The premium on top of variable rate for base stable borrowing rate
+   * @param stableRateExcessOffset The premium on top of stable rate when there stable debt surpass the threshold
+   * @param optimalStableToTotalDebtRatio The optimal stable debt to total debt ratio of the reserve
+   */
+  constructor(
+    IPoolAddressesProvider provider,
+    address rateSource,
+    uint256 optimalUsageRatio,
+    uint256 baseVariableBorrowRateSpread,
+    uint256 variableRateSlope1,
+    uint256 variableRateSlope2,
+    uint256 stableRateSlope1,
+    uint256 stableRateSlope2,
+    uint256 baseStableRateOffset,
+    uint256 stableRateExcessOffset,
+    uint256 optimalStableToTotalDebtRatio
+  ) {
+    require(WadRayMath.RAY >= optimalUsageRatio, Errors.INVALID_OPTIMAL_USAGE_RATIO);
+    require(
+      WadRayMath.RAY >= optimalStableToTotalDebtRatio,
+      Errors.INVALID_OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO
+    );
+    OPTIMAL_USAGE_RATIO = optimalUsageRatio;
+    MAX_EXCESS_USAGE_RATIO = WadRayMath.RAY - optimalUsageRatio;
+    OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO = optimalStableToTotalDebtRatio;
+    MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO = WadRayMath.RAY - optimalStableToTotalDebtRatio;
+    ADDRESSES_PROVIDER = provider;
+    RATE_SOURCE = IRateSource(rateSource);
+    _baseVariableBorrowRateSpread = baseVariableBorrowRateSpread;
+    _variableRateSlope1 = variableRateSlope1;
+    _variableRateSlope2 = variableRateSlope2;
+    _stableRateSlope1 = stableRateSlope1;
+    _stableRateSlope2 = stableRateSlope2;
+    _baseStableRateOffset = baseStableRateOffset;
+    _stableRateExcessOffset = stableRateExcessOffset;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getVariableRateSlope1() external view returns (uint256) {
+    return _variableRateSlope1;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getVariableRateSlope2() external view returns (uint256) {
+    return _variableRateSlope2;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getStableRateSlope1() external view returns (uint256) {
+    return _stableRateSlope1;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getStableRateSlope2() external view returns (uint256) {
+    return _stableRateSlope2;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getStableRateExcessOffset() external view returns (uint256) {
+    return _stableRateExcessOffset;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getBaseStableBorrowRate() public view returns (uint256) {
+    return _variableRateSlope1 + _baseStableRateOffset;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getBaseVariableBorrowRate() public view override returns (uint256) {
+    uint256 apr = RATE_SOURCE.getAPR();
+    return apr + _baseVariableBorrowRateSpread;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getMaxVariableBorrowRate() external view override returns (uint256) {
+    return getBaseVariableBorrowRate() + _variableRateSlope1 + _variableRateSlope2;
+  }
+
+  struct CalcInterestRatesLocalVars {
+    uint256 availableLiquidity;
+    uint256 totalDebt;
+    uint256 currentVariableBorrowRate;
+    uint256 currentStableBorrowRate;
+    uint256 currentLiquidityRate;
+    uint256 borrowUsageRatio;
+    uint256 supplyUsageRatio;
+    uint256 stableToTotalDebtRatio;
+    uint256 availableLiquidityPlusDebt;
+  }
+
+  /// @inheritdoc IReserveInterestRateStrategy
+  function calculateInterestRates(
+    DataTypes.CalculateInterestRatesParams memory params
+  ) public view override returns (uint256, uint256, uint256) {
+    CalcInterestRatesLocalVars memory vars;
+
+    vars.totalDebt = params.totalStableDebt + params.totalVariableDebt;
+
+    vars.currentLiquidityRate = 0;
+    vars.currentVariableBorrowRate = getBaseVariableBorrowRate();
+    vars.currentStableBorrowRate = getBaseStableBorrowRate();
+
+    if (vars.totalDebt != 0) {
+      vars.stableToTotalDebtRatio = params.totalStableDebt.rayDiv(vars.totalDebt);
+      vars.availableLiquidity =
+        IERC20(params.reserve).balanceOf(params.aToken) +
+        params.liquidityAdded -
+        params.liquidityTaken;
+
+      vars.availableLiquidityPlusDebt = vars.availableLiquidity + vars.totalDebt;
+      vars.borrowUsageRatio = vars.totalDebt.rayDiv(vars.availableLiquidityPlusDebt);
+      vars.supplyUsageRatio = vars.totalDebt.rayDiv(
+        vars.availableLiquidityPlusDebt + params.unbacked
+      );
+    }
+
+    if (vars.borrowUsageRatio > OPTIMAL_USAGE_RATIO) {
+      uint256 excessBorrowUsageRatio = (vars.borrowUsageRatio - OPTIMAL_USAGE_RATIO).rayDiv(
+        MAX_EXCESS_USAGE_RATIO
+      );
+
+      vars.currentStableBorrowRate +=
+        _stableRateSlope1 +
+        _stableRateSlope2.rayMul(excessBorrowUsageRatio);
+
+      vars.currentVariableBorrowRate +=
+        _variableRateSlope1 +
+        _variableRateSlope2.rayMul(excessBorrowUsageRatio);
+    } else {
+      vars.currentStableBorrowRate += _stableRateSlope1.rayMul(vars.borrowUsageRatio).rayDiv(
+        OPTIMAL_USAGE_RATIO
+      );
+
+      vars.currentVariableBorrowRate += _variableRateSlope1.rayMul(vars.borrowUsageRatio).rayDiv(
+        OPTIMAL_USAGE_RATIO
+      );
+    }
+
+    if (vars.stableToTotalDebtRatio > OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO) {
+      uint256 excessStableDebtRatio = (vars.stableToTotalDebtRatio -
+        OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO).rayDiv(MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO);
+      vars.currentStableBorrowRate += _stableRateExcessOffset.rayMul(excessStableDebtRatio);
+    }
+
+    vars.currentLiquidityRate = _getOverallBorrowRate(
+      params.totalStableDebt,
+      params.totalVariableDebt,
+      vars.currentVariableBorrowRate,
+      params.averageStableBorrowRate
+    ).rayMul(vars.supplyUsageRatio).percentMul(
+        PercentageMath.PERCENTAGE_FACTOR - params.reserveFactor
+      );
+
+    return (
+      vars.currentLiquidityRate,
+      vars.currentStableBorrowRate,
+      vars.currentVariableBorrowRate
+    );
+  }
+
+  /**
+   * @dev Calculates the overall borrow rate as the weighted average between the total variable debt and total stable
+   * debt
+   * @param totalStableDebt The total borrowed from the reserve at a stable rate
+   * @param totalVariableDebt The total borrowed from the reserve at a variable rate
+   * @param currentVariableBorrowRate The current variable borrow rate of the reserve
+   * @param currentAverageStableBorrowRate The current weighted average of all the stable rate loans
+   * @return The weighted averaged borrow rate
+   */
+  function _getOverallBorrowRate(
+    uint256 totalStableDebt,
+    uint256 totalVariableDebt,
+    uint256 currentVariableBorrowRate,
+    uint256 currentAverageStableBorrowRate
+  ) internal pure returns (uint256) {
+    uint256 totalDebt = totalStableDebt + totalVariableDebt;
+
+    if (totalDebt == 0) return 0;
+
+    uint256 weightedVariableRate = totalVariableDebt.wadToRay().rayMul(currentVariableBorrowRate);
+
+    uint256 weightedStableRate = totalStableDebt.wadToRay().rayMul(currentAverageStableBorrowRate);
+
+    uint256 overallBorrowRate = (weightedVariableRate + weightedStableRate).rayDiv(
+      totalDebt.wadToRay()
+    );
+
+    return overallBorrowRate;
+  }
+}

--- a/src/RateTargetKinkInterestRateStrategy.sol
+++ b/src/RateTargetKinkInterestRateStrategy.sol
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {IERC20} from 'aave-v3-core/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
+import {WadRayMath} from 'aave-v3-core/contracts/protocol/libraries/math/WadRayMath.sol';
+import {PercentageMath} from 'aave-v3-core/contracts/protocol/libraries/math/PercentageMath.sol';
+import {DataTypes} from 'aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol';
+import {Errors} from 'aave-v3-core/contracts/protocol/libraries/helpers/Errors.sol';
+import {IDefaultInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IDefaultInterestRateStrategy.sol';
+import {IReserveInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IReserveInterestRateStrategy.sol';
+import {IPoolAddressesProvider} from 'aave-v3-core/contracts/interfaces/IPoolAddressesProvider.sol';
+
+interface IRateSource {
+  function getAPR() external view returns (uint256);
+}
+
+/**
+ * @title RateTargetKinkInterestRateStrategy contract
+ * @author Aave
+ * @notice Implements the calculation of the interest rates depending on the reserve state and an external APR to target at the kink
+ * @dev The model of interest rate is based on 2 slopes, one before the `OPTIMAL_USAGE_RATIO`
+ * point of usage and another from that one to 100%.
+ * - An instance of this same contract, can't be used across different Aave markets, due to the caching
+ *   of the PoolAddressesProvider
+ */
+contract RateTargetKinkInterestRateStrategy is IDefaultInterestRateStrategy {
+  using WadRayMath for uint256;
+  using PercentageMath for uint256;
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  uint256 public immutable OPTIMAL_USAGE_RATIO;
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  uint256 public immutable OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO;
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  uint256 public immutable MAX_EXCESS_USAGE_RATIO;
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  uint256 public immutable MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO;
+
+  IPoolAddressesProvider public immutable ADDRESSES_PROVIDER;
+
+  IRateSource public immutable RATE_SOURCE;
+
+  // Base variable borrow rate when usage rate = 0. Expressed in ray
+  uint256 internal immutable _baseVariableBorrowRate;
+
+  // Slope spread of the variable interest curve when usage ratio > 0 and <= OPTIMAL_USAGE_RATIO. Expressed in ray
+  uint256 internal immutable _variableRateSlope1Spread;
+
+  // Slope of the variable interest curve when usage ratio > OPTIMAL_USAGE_RATIO. Expressed in ray
+  uint256 internal immutable _variableRateSlope2;
+
+  // Slope of the stable interest curve when usage ratio > 0 and <= OPTIMAL_USAGE_RATIO. Expressed in ray
+  uint256 internal immutable _stableRateSlope1;
+
+  // Slope of the stable interest curve when usage ratio > OPTIMAL_USAGE_RATIO. Expressed in ray
+  uint256 internal immutable _stableRateSlope2;
+
+  // Premium on top of `_variableRateSlope1` for base stable borrowing rate
+  uint256 internal immutable _baseStableRateOffset;
+
+  // Additional premium applied to stable rate when stable debt surpass `OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO`
+  uint256 internal immutable _stableRateExcessOffset;
+
+  /**
+   * @dev Constructor.
+   * @param provider The address of the PoolAddressesProvider contract
+   * @param rateSource The address of the rate source contract
+   * @param optimalUsageRatio The optimal usage ratio
+   * @param baseVariableBorrowRate The base variable borrow rate
+   * @param variableRateSlope1Spread The variable rate slope spread below optimal usage ratio
+   * @param variableRateSlope2 The variable rate slope above optimal usage ratio
+   * @param stableRateSlope1 The stable rate slope below optimal usage ratio
+   * @param stableRateSlope2 The stable rate slope above optimal usage ratio
+   * @param baseStableRateOffset The premium on top of variable rate for base stable borrowing rate
+   * @param stableRateExcessOffset The premium on top of stable rate when there stable debt surpass the threshold
+   * @param optimalStableToTotalDebtRatio The optimal stable debt to total debt ratio of the reserve
+   */
+  constructor(
+    IPoolAddressesProvider provider,
+    address rateSource,
+    uint256 optimalUsageRatio,
+    uint256 baseVariableBorrowRate,
+    uint256 variableRateSlope1Spread,
+    uint256 variableRateSlope2,
+    uint256 stableRateSlope1,
+    uint256 stableRateSlope2,
+    uint256 baseStableRateOffset,
+    uint256 stableRateExcessOffset,
+    uint256 optimalStableToTotalDebtRatio
+  ) {
+    require(WadRayMath.RAY >= optimalUsageRatio, Errors.INVALID_OPTIMAL_USAGE_RATIO);
+    require(
+      WadRayMath.RAY >= optimalStableToTotalDebtRatio,
+      Errors.INVALID_OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO
+    );
+    OPTIMAL_USAGE_RATIO = optimalUsageRatio;
+    MAX_EXCESS_USAGE_RATIO = WadRayMath.RAY - optimalUsageRatio;
+    OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO = optimalStableToTotalDebtRatio;
+    MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO = WadRayMath.RAY - optimalStableToTotalDebtRatio;
+    ADDRESSES_PROVIDER = provider;
+    RATE_SOURCE = IRateSource(rateSource);
+    _baseVariableBorrowRate = baseVariableBorrowRate;
+    _variableRateSlope1Spread = variableRateSlope1Spread;
+    _variableRateSlope2 = variableRateSlope2;
+    _stableRateSlope1 = stableRateSlope1;
+    _stableRateSlope2 = stableRateSlope2;
+    _baseStableRateOffset = baseStableRateOffset;
+    _stableRateExcessOffset = stableRateExcessOffset;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getVariableRateSlope1() public view returns (uint256) {
+    uint256 apr = RATE_SOURCE.getAPR();
+    if (_variableRateSlope1Spread > apr) {
+      return 0;
+    } else {
+      unchecked {
+        return apr - _variableRateSlope1Spread;
+      }
+    }
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getVariableRateSlope2() external view returns (uint256) {
+    return _variableRateSlope2;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getStableRateSlope1() external view returns (uint256) {
+    return _stableRateSlope1;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getStableRateSlope2() external view returns (uint256) {
+    return _stableRateSlope2;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getStableRateExcessOffset() external view returns (uint256) {
+    return _stableRateExcessOffset;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getBaseStableBorrowRate() public view returns (uint256) {
+    return getVariableRateSlope1() + _baseStableRateOffset;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getBaseVariableBorrowRate() external view override returns (uint256) {
+    return _baseVariableBorrowRate;
+  }
+
+  /// @inheritdoc IDefaultInterestRateStrategy
+  function getMaxVariableBorrowRate() external view override returns (uint256) {
+    return _baseVariableBorrowRate + getVariableRateSlope1() + _variableRateSlope2;
+  }
+
+  struct CalcInterestRatesLocalVars {
+    uint256 availableLiquidity;
+    uint256 totalDebt;
+    uint256 currentVariableBorrowRate;
+    uint256 currentStableBorrowRate;
+    uint256 currentLiquidityRate;
+    uint256 borrowUsageRatio;
+    uint256 supplyUsageRatio;
+    uint256 stableToTotalDebtRatio;
+    uint256 availableLiquidityPlusDebt;
+  }
+
+  /// @inheritdoc IReserveInterestRateStrategy
+  function calculateInterestRates(
+    DataTypes.CalculateInterestRatesParams memory params
+  ) public view override returns (uint256, uint256, uint256) {
+    CalcInterestRatesLocalVars memory vars;
+
+    vars.totalDebt = params.totalStableDebt + params.totalVariableDebt;
+
+    vars.currentLiquidityRate = 0;
+    vars.currentVariableBorrowRate = _baseVariableBorrowRate;
+    vars.currentStableBorrowRate = getBaseStableBorrowRate();
+
+    if (vars.totalDebt != 0) {
+      vars.stableToTotalDebtRatio = params.totalStableDebt.rayDiv(vars.totalDebt);
+      vars.availableLiquidity =
+        IERC20(params.reserve).balanceOf(params.aToken) +
+        params.liquidityAdded -
+        params.liquidityTaken;
+
+      vars.availableLiquidityPlusDebt = vars.availableLiquidity + vars.totalDebt;
+      vars.borrowUsageRatio = vars.totalDebt.rayDiv(vars.availableLiquidityPlusDebt);
+      vars.supplyUsageRatio = vars.totalDebt.rayDiv(
+        vars.availableLiquidityPlusDebt + params.unbacked
+      );
+    }
+
+    if (vars.borrowUsageRatio > OPTIMAL_USAGE_RATIO) {
+      uint256 excessBorrowUsageRatio = (vars.borrowUsageRatio - OPTIMAL_USAGE_RATIO).rayDiv(
+        MAX_EXCESS_USAGE_RATIO
+      );
+
+      vars.currentStableBorrowRate +=
+        _stableRateSlope1 +
+        _stableRateSlope2.rayMul(excessBorrowUsageRatio);
+
+      vars.currentVariableBorrowRate +=
+        getVariableRateSlope1() +
+        _variableRateSlope2.rayMul(excessBorrowUsageRatio);
+    } else {
+      vars.currentStableBorrowRate += _stableRateSlope1.rayMul(vars.borrowUsageRatio).rayDiv(
+        OPTIMAL_USAGE_RATIO
+      );
+
+      vars.currentVariableBorrowRate += getVariableRateSlope1().rayMul(vars.borrowUsageRatio).rayDiv(
+        OPTIMAL_USAGE_RATIO
+      );
+    }
+
+    if (vars.stableToTotalDebtRatio > OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO) {
+      uint256 excessStableDebtRatio = (vars.stableToTotalDebtRatio -
+        OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO).rayDiv(MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO);
+      vars.currentStableBorrowRate += _stableRateExcessOffset.rayMul(excessStableDebtRatio);
+    }
+
+    vars.currentLiquidityRate = _getOverallBorrowRate(
+      params.totalStableDebt,
+      params.totalVariableDebt,
+      vars.currentVariableBorrowRate,
+      params.averageStableBorrowRate
+    ).rayMul(vars.supplyUsageRatio).percentMul(
+        PercentageMath.PERCENTAGE_FACTOR - params.reserveFactor
+      );
+
+    return (
+      vars.currentLiquidityRate,
+      vars.currentStableBorrowRate,
+      vars.currentVariableBorrowRate
+    );
+  }
+
+  /**
+   * @dev Calculates the overall borrow rate as the weighted average between the total variable debt and total stable
+   * debt
+   * @param totalStableDebt The total borrowed from the reserve at a stable rate
+   * @param totalVariableDebt The total borrowed from the reserve at a variable rate
+   * @param currentVariableBorrowRate The current variable borrow rate of the reserve
+   * @param currentAverageStableBorrowRate The current weighted average of all the stable rate loans
+   * @return The weighted averaged borrow rate
+   */
+  function _getOverallBorrowRate(
+    uint256 totalStableDebt,
+    uint256 totalVariableDebt,
+    uint256 currentVariableBorrowRate,
+    uint256 currentAverageStableBorrowRate
+  ) internal pure returns (uint256) {
+    uint256 totalDebt = totalStableDebt + totalVariableDebt;
+
+    if (totalDebt == 0) return 0;
+
+    uint256 weightedVariableRate = totalVariableDebt.wadToRay().rayMul(currentVariableBorrowRate);
+
+    uint256 weightedStableRate = totalStableDebt.wadToRay().rayMul(currentAverageStableBorrowRate);
+
+    uint256 overallBorrowRate = (weightedVariableRate + weightedStableRate).rayDiv(
+      totalDebt.wadToRay()
+    );
+
+    return overallBorrowRate;
+  }
+}

--- a/test/RateTargetBaseInterestRateStrategy.t.sol
+++ b/test/RateTargetBaseInterestRateStrategy.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.10;
+
+import "forge-std/Test.sol";
+
+import { RateSourceMock } from "./mocks/RateSourceMock.sol";
+
+import {
+    RateTargetBaseInterestRateStrategy,
+    IPoolAddressesProvider
+} from "../src/RateTargetBaseInterestRateStrategy.sol";
+
+contract RateTargetBaseInterestRateStrategyTest is Test {
+
+    RateSourceMock rateSource;
+
+    RateTargetBaseInterestRateStrategy interestStrategy;
+
+    function setUp() public {
+        rateSource = new RateSourceMock(0.05e27);
+
+        interestStrategy = new RateTargetBaseInterestRateStrategy({
+            provider: IPoolAddressesProvider(address(123)),
+            rateSource: address(rateSource),
+            optimalUsageRatio: 0,
+            baseVariableBorrowRateSpread: 0.005e27,
+            variableRateSlope1: 0.01e27,
+            variableRateSlope2: 0.45e27,
+            stableRateSlope1: 0,
+            stableRateSlope2: 0,
+            baseStableRateOffset: 0,
+            stableRateExcessOffset: 0,
+            optimalStableToTotalDebtRatio: 0
+        });
+    }
+
+    function test_constructor() public {
+        assertEq(address(interestStrategy.ADDRESSES_PROVIDER()), address(123));
+        assertEq(address(interestStrategy.RATE_SOURCE()), address(rateSource));
+        assertEq(interestStrategy.OPTIMAL_USAGE_RATIO(), 0);
+        assertEq(interestStrategy.OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO(), 0);
+        assertEq(interestStrategy.MAX_EXCESS_USAGE_RATIO(), 1e27);
+        assertEq(interestStrategy.MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO(), 1e27);
+        assertEq(interestStrategy.MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO(), 1e27);
+        assertEq(interestStrategy.getVariableRateSlope1(), 0.01e27);
+        assertEq(interestStrategy.getVariableRateSlope2(), 0.45e27);
+        assertEq(interestStrategy.getStableRateSlope1(), 0);
+        assertEq(interestStrategy.getStableRateSlope2(), 0);
+        assertEq(interestStrategy.getStableRateExcessOffset(), 0);
+        assertEq(interestStrategy.getBaseStableBorrowRate(), 0.01e27);
+        assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.055e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.515e27);
+    }
+
+    function test_rateSource_change() public {
+        assertEq(interestStrategy.getVariableRateSlope1(), 0.01e27);
+        assertEq(interestStrategy.getVariableRateSlope2(), 0.45e27);
+        assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.055e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.515e27);
+
+        rateSource.setRate(0.07e27);
+
+        assertEq(interestStrategy.getVariableRateSlope1(), 0.01e27);
+        assertEq(interestStrategy.getVariableRateSlope2(), 0.45e27);
+        assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.075e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.535e27);
+    }
+
+}

--- a/test/RateTargetBaseInterestRateStrategy.t.sol
+++ b/test/RateTargetBaseInterestRateStrategy.t.sol
@@ -36,34 +36,35 @@ contract RateTargetBaseInterestRateStrategyTest is Test {
 
     function test_constructor() public {
         assertEq(address(interestStrategy.ADDRESSES_PROVIDER()), address(123));
-        assertEq(address(interestStrategy.RATE_SOURCE()), address(rateSource));
-        assertEq(interestStrategy.OPTIMAL_USAGE_RATIO(), 0);
-        assertEq(interestStrategy.OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO(), 0);
-        assertEq(interestStrategy.MAX_EXCESS_USAGE_RATIO(), 1e27);
+        assertEq(address(interestStrategy.RATE_SOURCE()),        address(rateSource));
+
+        assertEq(interestStrategy.OPTIMAL_USAGE_RATIO(),                   0);
+        assertEq(interestStrategy.OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO(),    0);
+        assertEq(interestStrategy.MAX_EXCESS_USAGE_RATIO(),                1e27);
         assertEq(interestStrategy.MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO(), 1e27);
-        assertEq(interestStrategy.MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO(), 1e27);
-        assertEq(interestStrategy.getVariableRateSlope1(), 0.01e27);
-        assertEq(interestStrategy.getVariableRateSlope2(), 0.45e27);
-        assertEq(interestStrategy.getStableRateSlope1(), 0);
-        assertEq(interestStrategy.getStableRateSlope2(), 0);
+
+        assertEq(interestStrategy.getVariableRateSlope1(),     0.01e27);
+        assertEq(interestStrategy.getVariableRateSlope2(),     0.45e27);
+        assertEq(interestStrategy.getStableRateSlope1(),       0);
+        assertEq(interestStrategy.getStableRateSlope2(),       0);
         assertEq(interestStrategy.getStableRateExcessOffset(), 0);
-        assertEq(interestStrategy.getBaseStableBorrowRate(), 0.01e27);
+        assertEq(interestStrategy.getBaseStableBorrowRate(),   0.01e27);
         assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.055e27);
-        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.515e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(),  0.515e27);
     }
 
     function test_rateSource_change() public {
-        assertEq(interestStrategy.getVariableRateSlope1(), 0.01e27);
-        assertEq(interestStrategy.getVariableRateSlope2(), 0.45e27);
+        assertEq(interestStrategy.getVariableRateSlope1(),     0.01e27);
+        assertEq(interestStrategy.getVariableRateSlope2(),     0.45e27);
         assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.055e27);
-        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.515e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(),  0.515e27);
 
         rateSource.setRate(0.07e27);
 
-        assertEq(interestStrategy.getVariableRateSlope1(), 0.01e27);
-        assertEq(interestStrategy.getVariableRateSlope2(), 0.45e27);
+        assertEq(interestStrategy.getVariableRateSlope1(),     0.01e27);
+        assertEq(interestStrategy.getVariableRateSlope2(),     0.45e27);
         assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.075e27);
-        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.535e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(),  0.535e27);
     }
 
 }

--- a/test/RateTargetKinkInterestRateStrategy.t.sol
+++ b/test/RateTargetKinkInterestRateStrategy.t.sol
@@ -51,66 +51,67 @@ contract RateTargetKinkInterestRateStrategyTest is Test {
 
     function test_constructor() public {
         assertEq(address(interestStrategy.ADDRESSES_PROVIDER()), address(123));
-        assertEq(address(interestStrategy.RATE_SOURCE()), address(rateSource));
-        assertEq(interestStrategy.OPTIMAL_USAGE_RATIO(), 0);
-        assertEq(interestStrategy.OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO(), 0);
-        assertEq(interestStrategy.MAX_EXCESS_USAGE_RATIO(), 1e27);
-        assertEq(interestStrategy.MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO(), 1e27);
-        assertEq(interestStrategy.MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO(), 1e27);
-        assertEq(interestStrategy.getVariableRateSlope1(), 0.035e27);
-        assertEq(interestStrategy.getVariableRateSlope2(), 0.55e27);
-        assertEq(interestStrategy.getStableRateSlope1(), 0);
-        assertEq(interestStrategy.getStableRateSlope2(), 0);
-        assertEq(interestStrategy.getStableRateExcessOffset(), 0);
-        assertEq(interestStrategy.getBaseStableBorrowRate(), 0.035e27);
-        assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.01e27);
-        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.595e27);
+        assertEq(address(interestStrategy.RATE_SOURCE()),        address(rateSource));
 
-        assertEq(interestStrategyPositiveSpread.getVariableRateSlope1(), 0.045e27);
-        assertEq(interestStrategyPositiveSpread.getVariableRateSlope2(), 0.55e27);
+        assertEq(interestStrategy.OPTIMAL_USAGE_RATIO(),                   0);
+        assertEq(interestStrategy.OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO(),    0);
+        assertEq(interestStrategy.MAX_EXCESS_USAGE_RATIO(),                1e27);
+        assertEq(interestStrategy.MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO(), 1e27);
+
+        assertEq(interestStrategy.getVariableRateSlope1(),     0.035e27);
+        assertEq(interestStrategy.getVariableRateSlope2(),     0.55e27);
+        assertEq(interestStrategy.getStableRateSlope1(),       0);
+        assertEq(interestStrategy.getStableRateSlope2(),       0);
+        assertEq(interestStrategy.getStableRateExcessOffset(), 0);
+        assertEq(interestStrategy.getBaseStableBorrowRate(),   0.035e27);
+        assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.01e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(),  0.595e27);
+
+        assertEq(interestStrategyPositiveSpread.getVariableRateSlope1(),    0.045e27);
+        assertEq(interestStrategyPositiveSpread.getVariableRateSlope2(),    0.55e27);
         assertEq(interestStrategyPositiveSpread.getMaxVariableBorrowRate(), 0.605e27);
     }
 
     function test_rateSource_change_kink_above_base() public {
-        assertEq(interestStrategy.getVariableRateSlope1(), 0.035e27);
-        assertEq(interestStrategy.getVariableRateSlope2(), 0.55e27);
+        assertEq(interestStrategy.getVariableRateSlope1(),     0.035e27);
+        assertEq(interestStrategy.getVariableRateSlope2(),     0.55e27);
         assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.01e27);
-        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.595e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(),  0.595e27);
 
         rateSource.setRate(0.07e27);
 
-        assertEq(interestStrategy.getVariableRateSlope1(), 0.055e27);
-        assertEq(interestStrategy.getVariableRateSlope2(), 0.55e27);
+        assertEq(interestStrategy.getVariableRateSlope1(),     0.055e27);
+        assertEq(interestStrategy.getVariableRateSlope2(),     0.55e27);
         assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.01e27);
-        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.615e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(),  0.615e27);
     }
 
     function test_rateSource_change_kink_below_base() public {
-        assertEq(interestStrategy.getVariableRateSlope1(), 0.035e27);
-        assertEq(interestStrategy.getVariableRateSlope2(), 0.55e27);
+        assertEq(interestStrategy.getVariableRateSlope1(),     0.035e27);
+        assertEq(interestStrategy.getVariableRateSlope2(),     0.55e27);
         assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.01e27);
-        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.595e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(),  0.595e27);
 
         rateSource.setRate(0.012e27);   // 1.2% - 0.5% = 0.7% < 1.0%
 
-        assertEq(interestStrategy.getVariableRateSlope1(), 0);
-        assertEq(interestStrategy.getVariableRateSlope2(), 0.55e27);
+        assertEq(interestStrategy.getVariableRateSlope1(),     0);
+        assertEq(interestStrategy.getVariableRateSlope2(),     0.55e27);
         assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.01e27);
-        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.56e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(),  0.56e27);
     }
 
     function test_rateSource_change_rate_below_base() public {
-        assertEq(interestStrategy.getVariableRateSlope1(), 0.035e27);
-        assertEq(interestStrategy.getVariableRateSlope2(), 0.55e27);
+        assertEq(interestStrategy.getVariableRateSlope1(),     0.035e27);
+        assertEq(interestStrategy.getVariableRateSlope2(),     0.55e27);
         assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.01e27);
-        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.595e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(),  0.595e27);
 
         rateSource.setRate(0);
 
-        assertEq(interestStrategy.getVariableRateSlope1(), 0);
-        assertEq(interestStrategy.getVariableRateSlope2(), 0.55e27);
+        assertEq(interestStrategy.getVariableRateSlope1(),     0);
+        assertEq(interestStrategy.getVariableRateSlope2(),     0.55e27);
         assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.01e27);
-        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.56e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(),  0.56e27);
     }
 
 }

--- a/test/RateTargetKinkInterestRateStrategy.t.sol
+++ b/test/RateTargetKinkInterestRateStrategy.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.10;
+
+import "forge-std/Test.sol";
+
+import { RateSourceMock } from "./mocks/RateSourceMock.sol";
+
+import {
+    RateTargetKinkInterestRateStrategy,
+    IPoolAddressesProvider
+} from "../src/RateTargetKinkInterestRateStrategy.sol";
+
+contract RateTargetKinkInterestRateStrategyTest is Test {
+
+    RateSourceMock rateSource;
+
+    RateTargetKinkInterestRateStrategy interestStrategy;
+
+    function setUp() public {
+        rateSource = new RateSourceMock(0.05e27);
+
+        interestStrategy = new RateTargetKinkInterestRateStrategy({
+            provider: IPoolAddressesProvider(address(123)),
+            rateSource: address(rateSource),
+            optimalUsageRatio: 0,
+            baseVariableBorrowRate: 0.01e27,
+            variableRateSlope1Spread: 0.015e27,
+            variableRateSlope2: 0.55e27,
+            stableRateSlope1: 0,
+            stableRateSlope2: 0,
+            baseStableRateOffset: 0,
+            stableRateExcessOffset: 0,
+            optimalStableToTotalDebtRatio: 0
+        });
+    }
+
+    function test_constructor() public {
+        assertEq(address(interestStrategy.ADDRESSES_PROVIDER()), address(123));
+        assertEq(address(interestStrategy.RATE_SOURCE()), address(rateSource));
+        assertEq(interestStrategy.OPTIMAL_USAGE_RATIO(), 0);
+        assertEq(interestStrategy.OPTIMAL_STABLE_TO_TOTAL_DEBT_RATIO(), 0);
+        assertEq(interestStrategy.MAX_EXCESS_USAGE_RATIO(), 1e27);
+        assertEq(interestStrategy.MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO(), 1e27);
+        assertEq(interestStrategy.MAX_EXCESS_STABLE_TO_TOTAL_DEBT_RATIO(), 1e27);
+        assertEq(interestStrategy.getVariableRateSlope1(), 0.035e27);
+        assertEq(interestStrategy.getVariableRateSlope2(), 0.55e27);
+        assertEq(interestStrategy.getStableRateSlope1(), 0);
+        assertEq(interestStrategy.getStableRateSlope2(), 0);
+        assertEq(interestStrategy.getStableRateExcessOffset(), 0);
+        assertEq(interestStrategy.getBaseStableBorrowRate(), 0.035e27);
+        assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.01e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.595e27);
+    }
+
+    function test_rateSource_change() public {
+        assertEq(interestStrategy.getVariableRateSlope1(), 0.035e27);
+        assertEq(interestStrategy.getVariableRateSlope2(), 0.55e27);
+        assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.01e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.595e27);
+
+        rateSource.setRate(0.07e27);
+
+        assertEq(interestStrategy.getVariableRateSlope1(), 0.055e27);
+        assertEq(interestStrategy.getVariableRateSlope2(), 0.55e27);
+        assertEq(interestStrategy.getBaseVariableBorrowRate(), 0.01e27);
+        assertEq(interestStrategy.getMaxVariableBorrowRate(), 0.615e27);
+    }
+
+}

--- a/test/mocks/RateSourceMock.sol
+++ b/test/mocks/RateSourceMock.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+contract RateSourceMock {
+
+    uint256 public rate;
+
+    constructor(uint256 _rate) {
+        rate = _rate;
+    }
+
+    function setRate(uint256 _rate) external {
+        rate = _rate;
+    }
+
+    function getAPR() external view returns (uint256) {
+        return rate;
+    }
+
+}


### PR DESCRIPTION
Reads a dynamic rate to target instead of hard coded values. There are a few uses for this:

Kinked version: Will be used for USDC/USDT markets on mainnet to target just under the DSR. Can also be used for ETH market if/when we get a good measure of APR for staked eth yield.

Base version: Targeting DAI market to be some spread above the DSR yield.

I would diff against the Default IRS to compare the changes.

This will work cross-chain with the DSR Oracle: https://github.com/marsfoundation/xchain-dsr-oracle/blob/SC-167-build-mvp/src/DSROracleBase.sol